### PR TITLE
Allow assignment in conditional statements.

### DIFF
--- a/rules/errors.js
+++ b/rules/errors.js
@@ -12,7 +12,7 @@ module.exports = {
     "comma-dangle": [2, "always-multiline"],
 
     // http://eslint.org/docs/rules/no-cond-assign
-    "no-cond-assign": [2, "always"],
+    "no-cond-assign": [2, "except-parens"],
 
     // http://eslint.org/docs/rules/no-console
     "no-console": 1,


### PR DESCRIPTION
Closes https://github.com/izaakschroeder/eslint-config-metalab/issues/4.

Placing an assignment inside a conditional can be useful. Assignments must be wrapped in parens to be valid.

``` js
// Practical example that wraps the assignment and tests for 'null'
function setHeight(someNode) {
    "use strict";
    do {
        someNode.height = "100px";
    } while ((someNode = someNode.parentNode) !== null);
}
```
