### PR TITLE
Update documentation for variety of rules; tweak a few.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eslint-config-metalab
 
-Lint JavaScript MetaLab style.
+Lint JavaScript [MetaLab] style.
 
 ## Usage
 
@@ -52,3 +52,5 @@ So you've set everything up but you're getting hundreds of errors because your p
 ```
 
 Clean up the low hanging fruit and progressively iterate to bring beauty and inner peace to your project. :gem:
+
+[MetaLab]: http://www.metalab.co

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   },
   "peerDependencies": {
     "eslint": "^1.8.0"
+  },
+  "devDependencies": {
+    "eslint": "^1.8.0"
   }
 }

--- a/rules/babel.js
+++ b/rules/babel.js
@@ -1,5 +1,7 @@
 module.exports = {
   // Use the power of babel for parsing. This allows for use of newer versions
-  // of Javascript and things like JSX.
+  // of Javascript and things like JSX. It provides a more consistent experience
+  // than trying to use eslint's native `espree`.
+  // See: https://github.com/babel/babel-eslint
   parser: 'babel-eslint',
 };

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -1,109 +1,199 @@
 module.exports = {
+  // For complete listing of rules and what they do, check out the docs.
+  // See: https://github.com/eslint/eslint/tree/master/docs/rules
   rules: {
     // ----------------------------------------------------------------------
     // Best practices
     // ----------------------------------------------------------------------
 
+    // This rule is aimed at ensuring all return statements either specify a
+    // value or don't specify a value. Since JavaScript offers no typing
+    // it is impossible to check a function actually returns what it intends to.
+    // This is a helping hand in the right direction.
     // http://eslint.org/docs/rules/consistent-return
     'consistent-return': 2,
 
+    // It is considered by many to be best practice to never omit curly braces
+    // around blocks, even when they are optional, because it can lead to bugs
+    // and reduces code clarity.
     // http://eslint.org/docs/rules/curly
     'curly': [ 2, 'multi-line' ],
 
     // Enforce a reasonable cap on functions spiralling out of control
     // with many branches.
+    // http://eslint.org/docs/rules/complexity
     'complexity': [ 2, 10 ],
 
     // If you have a switch block you should always cover all possible cases.
-    // Since Javascript has a shit type system we have to have a default case
+    // Since Javascript has a bad "type system" we have to have a default case
     // to check everything.
     // http://eslint.org/docs/rules/default-case
     'default-case': 2,
 
+    // Dot notation is often preferred because it is easier to read, less
+    // verbose, and works better with aggressive JavaScript minimizers.
     // http://eslint.org/docs/rules/dot-notation
     'dot-notation': [ 2, {
       allowKeywords: true,
     } ],
 
+    // JavaScript "types" to the rescue again! `==` offers incredibly
+    // inconsistent checking resulting in hard-to-find errors.
     // http://eslint.org/docs/rules/eqeqeq
+    // http://stackoverflow.com/questions/359494
     'eqeqeq': 2,
 
+    // Looping over objects with a for in loop will include properties that are
+    // inherited through the prototype chain. This behavior can lead to
+    // unexpected items in your for loop. You can use `for ... of` and/or
+    // `Object.getOwnPropertyNames` or `Object.keys`.
     // http://eslint.org/docs/rules/guard-for-in
     'guard-for-in': 2,
 
+    // The use of arguments.caller and arguments.callee make several code
+    // optimizations impossible. They have been deprecated in future versions of
+    // JavaScript. May as well force good choices on the code.
     // http://eslint.org/docs/rules/no-caller
     'no-caller': 2,
 
+    // Save some bytes! Also prevent some possible dead code paths.
     // http://eslint.org/docs/rules/no-else-return
     'no-else-return': 2,
 
+    // Comparing to null without a type-checking operator (== or !=), can have
+    // unintended results as the comparison will evaluate to true when comparing
+    // to not just a null, but also an undefined value. This isn't a big deal
+    // with `eqeqeq` on, so it's more here for consistency.
     // http://eslint.org/docs/rules/no-eq-null
-    'no-eq-null': 0,
+    'no-eq-null': 2,
 
+    // The devil of all functions. `eval` is terrible for thousands of reasons.
     // http://eslint.org/docs/rules/no-eval
+    // http://stackoverflow.com/questions/86513
     'no-eval': 2,
 
+    // Almost always results in nasty, hard to find bugs. Changing native/shared
+    // code can mean changes in expected behavior in other places.
     // http://eslint.org/docs/rules/no-extend-native
     'no-extend-native': 2,
 
+    // Sometimes during the course of code maintenance, the this value is
+    // removed from the function body. In that case, you can end up with a call
+    //  to bind() that doesn't accomplish anything. So save the performance.
     // http://eslint.org/docs/rules/no-extra-bind
     'no-extra-bind': 2,
 
+    // The switch statement in JavaScript is one of the more error-prone
+    // constructs of the language thanks in part to the ability to "fall
+    // through" from one case to the next. More often than not this is NOT
+    // what you want, so explicitly disable it.
     // http://eslint.org/docs/rules/no-fallthrough
     'no-fallthrough': 2,
 
-    // Don't allow people to do dumb things like "1." when they mean "1.0".
+    // Don't allow people to do silly things like "1." when they mean "1.0".
     // http://eslint.org/docs/rules/no-floating-decimal
     'no-floating-decimal': 2,
 
+    // There are some other ways to pass a string and have it interpreted as
+    // code. Disable them for the same reasons as `eval`.
     // http://eslint.org/docs/rules/no-implied-eval
     'no-implied-eval': 2,
 
+    // In JavaScript, prior to ES6, standalone code blocks delimited by curly
+    // braces do not create a new scope and have no use.
     // http://eslint.org/docs/rules/no-lone-blocks
     'no-lone-blocks': 2,
 
+    // Writing functions within loops tends to result in errors due to the way
+    // the function creates a closure around the loop. If functions are needed
+    // in loops, set the iterator variable with `let` instead of `var` or use an
+    //  iterator function like `forEach`.
     // http://eslint.org/docs/rules/no-loop-func
     'no-loop-func': 2,
 
+    // It's possible to create multiline strings in JavaScript by using a slash
+    // before a newline. Use template strings instead.
     // http://eslint.org/docs/rules/no-multi-str
     'no-multi-str': 2,
 
+    // Reports an error when they encounter an attempt to assign a value to
+    // built-in native object. There should be no valid reason anyone is trying
+    // to assign values to built-ins.
     // http://eslint.org/docs/rules/no-native-reassign
     'no-native-reassign': 2,
 
+    // Don't use `new` for side-effects. Since `new` always creates an object
+    // instances, not consuming that object is wasteful and generally indicative
+    // of programmer error. Sometimes this is handy in testing and in those
+    // cases exceptions can be made.
     // http://eslint.org/docs/rules/no-new
     'no-new': 2,
 
+    // It's possible to create functions in JavaScript using the Function
+    // constructor. This is considered by many to be a bad practice as it
+    // increases debugging difficultly and reading these types of functions.
     // http://eslint.org/docs/rules/no-new-func
     'no-new-func': 2,
 
+    // There are three primitive types in JavaScript that have wrapper objects:
+    // string, number, and boolean. Although possible, there aren't any good
+    // reasons to use these primitive wrappers as constructors. They tend to
+    // confuse other developers more than anything else because they seem like
+    // they should act as primitives, but they do not.
     // http://eslint.org/docs/rules/no-new-wrappers
     'no-new-wrappers': 2,
 
+    // The leading zero to identify an octal literal has been a source of
+    // confusion and error in JavaScript. ECMAScript 5 deprecates the use of
+    // octal numeric literals in JavaScript and octal literals cause syntax
+    // errors in strict mode.
     // http://eslint.org/docs/rules/no-octal
     'no-octal': 2,
 
+    // As of version 5 of the ECMAScript specification, octal escape sequences
+    // are a deprecated feature and should not be used. It is recommended that
+    // Unicode escapes be used instead.
     // http://eslint.org/docs/rules/no-octal-escape
     'no-octal-escape': 2,
 
+    // Assignment to variables declared as function parameters can be misleading
+    // and lead to confusing behavior, as modifying function parameters will
+    // also mutate the arguments object. Often, assignment to function
+    // parameters is unintended and indicative of a mistake or programmer error.
     // http://eslint.org/docs/rules/no-param-reassign
     'no-param-reassign': 2,
 
+    // The `__proto__` property has been deprecated as of ECMAScript 3.1 and
+    // shouldn't be used in the code. Use getPrototypeOf method instead.
     // http://eslint.org/docs/rules/no-proto
     'no-proto': 2,
 
+    // In JavaScript, it's possible to redeclare the same variable name using
+    // `var`. This can lead to confusion as to where the variable is actually
+    // declared and initialized. Just don't do it.
     // http://eslint.org/docs/rules/no-redeclare
     'no-redeclare': 2,
 
+    // Having an assignment expression in a `return` statement results in
+    // confusion, since nothing assigned will likely escape the function. Maybe
+    // it was intended to be a comparison. Maybe it wasn't intended at all.
+    // Just avoid the confusion entirely by forbidding this strange practice.
     // http://eslint.org/docs/rules/no-return-assign
     'no-return-assign': 2,
 
+    // Basically another form of `eval`.
     // http://eslint.org/docs/rules/no-script-url
     'no-script-url': 2,
 
+    // The only time you would compare a variable against itself is when you are
+    // testing for NaN. Use `Number.isNaN` or similar instead.
     // http://eslint.org/docs/rules/no-self-compare
     'no-self-compare': 2,
 
+    // The comma operator includes multiple expressions where only one is
+    // expected. It evaluates each operand from left to right and returns the
+    // value of the last operand. However, this frequently obscures side
+    // effects, and its use is often an accident.
     // http://eslint.org/docs/rules/no-sequences
     'no-sequences': 2,
 
@@ -111,15 +201,19 @@ module.exports = {
     // http://eslint.org/docs/rules/no-throw-literal
     'no-throw-literal': 2,
 
+    // The `with` keyword is evil second only to `eval`. Another source of
+    // confusing bugs and excellent way to defeat static analyzers.
     // http://eslint.org/docs/rules/no-with
+    // http://stackoverflow.com/questions/61552
     'no-with': 2,
 
     // Prevent weird behavior from `parseInt`.
-    // See: http://stackoverflow.com/questions/850341
     // http://eslint.org/docs/rules/radix
+    // http://stackoverflow.com/questions/850341
     'radix': 2,
 
-    // ?
+    // JavaScript's `var` declarations are function-scope, not lexical scope.
+    // Ensure that this fact is acknowledged by code.
     // http://eslint.org/docs/rules/vars-on-top
     'vars-on-top': 2,
 
@@ -127,7 +221,8 @@ module.exports = {
     // http://eslint.org/docs/rules/wrap-iife
     'wrap-iife': [ 2, 'any' ],
 
-    // ??
+    // Provide a consistent way of doing comparisons. This way is arguably a
+    // more natural way to describe the comparison.
     // http://eslint.org/docs/rules/yoda
     'yoda': 2,
   },

--- a/rules/docs.js
+++ b/rules/docs.js
@@ -1,6 +1,10 @@
 module.exports = {
+  // For complete listing of rules and what they do, check out the docs.
+  // See: https://github.com/eslint/eslint/tree/master/docs/rules
   rules: {
-    // Enforce good documentation.
+    // Enforce good documentation. Reduce the mental burden for when other
+    // people try to understand or consume your code.
+    // http://eslint.org/docs/rules/valid-jsdoc
     'valid-jsdoc': [ 2, {
       prefer: {
         return: 'returns',

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -5,77 +5,165 @@ module.exports = {
     // ----------------------------------------------------------------------
     // Possible errors
     // ----------------------------------------------------------------------
+
+    // Constructors of derived classes must call super(). Constructors of non-
+    // derived classes must not call super(). If this is not observed, the
+    // javascript engine will raise a runtime error. Having this rule allows
+    // for avoiding runtime errors by checking for this case early on.
+    // http://eslint.org/docs/rules/constructor-super
     'constructor-super': 2,
 
+    // While this looks a bit weird, its purpose is to make git diffs actually
+    // make sense. Without dangling commas diffs include unnecessary lines,
+    // sometimes making it hard to tell which lines were intended to be changed
+    // and making `git blame` mark one line with a possibly unrelated commit.
     // http://eslint.org/docs/rules/comma-dangle
     'comma-dangle': [ 2, 'always-multiline' ],
 
+    // In conditional statements, it is very easy to mistype a comparison
+    // operator (such as ==) as an assignment operator (such as =). This
+    // prevents those common mistakes and ensures assignment is actually
+    // intentional.
     // http://eslint.org/docs/rules/no-cond-assign
     'no-cond-assign': [ 2, 'except-parens' ],
 
+    // While fine for debugging, (or in exceptional cases like as a plugin to a
+    // logging mechanism), console output generally does not belong in
+    // production code.
     // http://eslint.org/docs/rules/no-console
-    'no-console': 1,
+    'no-console': 2,
 
+    // For the same reason console logging does not belong in production code,
+    // neither does `debugger`. A library or app consumer should never be
+    // dropped into the JS debugger for any reason.
     // http://eslint.org/docs/rules/no-debugger
-    'no-debugger': 1,
+    'no-debugger': 2,
 
+    // The `alert` dialog is just overall terrible. So prevent people from using
+    // it. They should be using a modal that fits the UX of their app.
     // http://eslint.org/docs/rules/no-alert
-    'no-alert': 1,
+    'no-alert': 2,
 
+    // Comparing a literal expression in a condition is usually a typo or
+    // development trigger for a specific behavior. e.g. `if (false) ...`
     // http://eslint.org/docs/rules/no-constant-condition
-    'no-constant-condition': 1,
+    'no-constant-condition': 2,
 
+    // Creating objects with duplicate keys in objects can cause unexpected
+    // behavior in your application. So prevent this esoteric case.
     // http://eslint.org/docs/rules/no-dupe-keys
     'no-dupe-keys': 2,
 
+    // A switch statements with duplicate case labels is normally an indication
+    // of a programmer error, since (in combination with `no-fallthrough`) only
+    // the first matching case will get executed creating dead code if you have
+    // duplicates.
     // http://eslint.org/docs/rules/no-duplicate-case
     'no-duplicate-case': 2,
 
+    // Empty block statements are usually an indicator of an error, or at the
+    // very least, an indicator that some refactoring is needed.
     // http://eslint.org/docs/rules/no-empty
     'no-empty': 2,
 
+    // When an error is caught using a `catch` block, it's possible to
+    // accidentally (or purposely) overwrite the reference to the error. This
+    // makes it impossible to track the error from that point on.
     // http://eslint.org/docs/rules/no-ex-assign
     'no-ex-assign': 2,
 
+    // No point in having unnecessary typecasts.
     // http://eslint.org/docs/rules/no-extra-boolean-cast
     'no-extra-boolean-cast': 0,
 
+    // No point in cluttering up the code with pointless semi-colons.
     // http://eslint.org/docs/rules/no-extra-semi
     'no-extra-semi': 2,
 
+    // Overwriting/reassigning a function written as a FunctionDeclaration is
+    // often indicative of a mistake or issue.
     // http://eslint.org/docs/rules/no-func-assign
     'no-func-assign': 2,
 
+    // In JavaScript, prior to ES6, a function declaration is only allowed in
+    // the first level of a program or the body of another function, though
+    // parsers sometimes erroneously accept them elsewhere. This only applies to
+    // function declarations; named or anonymous function expressions can occur
+    // anywhere an expression is permitted.
     // http://eslint.org/docs/rules/no-inner-declarations
     'no-inner-declarations': 2,
 
+    // Validates string arguments passed to the RegExp constructor. Seems like
+    // a sensible, extra safeguard to have.
     // http://eslint.org/docs/rules/no-invalid-regexp
     'no-invalid-regexp': 2,
 
+    // Invalid or irregular whitespace causes issues with ECMAScript 5 parsers
+    // and also makes code harder to debug in a similar nature to mixed tabs and
+    // spaces. Invalid whitespace is any whitespace character that is not a
+    // normal tab or space.
     // http://eslint.org/docs/rules/no-irregular-whitespace
     'no-irregular-whitespace': 2,
 
+    // ECMAScript provides several global objects that are intended to be used
+    // as-is. Some of these objects look as if they could be constructors due
+    // their capitalization (such as Math and JSON) but will throw an error if
+    // you try to execute them as functions. So catch these errors early on.
     // http://eslint.org/docs/rules/no-obj-calls
     'no-obj-calls': 2,
 
+    // Properties that are not valid identifiers need to be quoted. For example
+    // the property `foo-bar` needs quotes, while `fooBar` does not. Generally
+    // quotes are extra and unecessary since the majority of properties should
+    // be camel-cased. However, sometimes you need those odd-named properties.
     // http://eslint.org/docs/rules/quote-props
-    'quote-props': [ 2, 'consistent-as-needed' ],
+    'quote-props': [ 2, 'as-needed' ],
 
+    // Sparse arrays contain empty slots, most frequently due to multiple commas
+    // being used in an array literal. Did the developer intend for there to be
+    // an empty spot in the middle of the array? Or is it a typo? The confusion
+    // around sparse arrays defined in this manner is enough that it's
+    // recommended to avoid using them unless you are certain that they are
+    // useful in your code.
     // http://eslint.org/docs/rules/no-sparse-arrays
     'no-sparse-arrays': 2,
 
+    // Any reference to an undeclared variable causes an error. This helps you
+    // locate potential ReferenceErrors resulting from misspellings of variable
+    // and parameter names, or accidental implicit globals. Access to globals
+    // can be added via a /* global foo */ comment.
     // http://eslint.org/docs/rules/no-undef
     'no-undef': 2,
 
+    // A number of statements unconditionally exit a block of code. Any
+    // statements after that will not be executed and may be an error. The
+    // presence of unreachable code is usually a sign of a coding error.
     // http://eslint.org/docs/rules/no-unreachable
     'no-unreachable': 2,
 
+    // Variables that are declared and not used anywhere in the code are most
+    // likely an error due to incomplete refactoring. Such variables take up
+    // space in the code and can lead to confusion by readers.
     // http://eslint.org/docs/rules/no-unused-vars
     'no-unused-vars': 2,
 
+    // As par for the JavaScript course, NaN is one of the most confusing,
+    // inconsistent literals in existence. It's part of the IEEE floating
+    // point standard, but it's interactions in JavaScript are odd. NaN is not
+    // equal to anything, including itself. e.g. `5/0 === NaN` is false, even
+    // though 5/0 is NaN. JavaScript. Even `isNaN` is not perfect, but it is
+    // slightly less confusing. `isNaN(5/0)` is true, but `isNaN("NaN")` is
+    // also true. This rule is here just to guard against simple errors, but
+    // does not cover the scope of the garbage that is JS NaN. See below links
+    // for further discussion.
     // http://eslint.org/docs/rules/use-isnan
+    // http://stackoverflow.com/questions/25176459
     'use-isnan': 2,
 
+    // This rule aims to reduce the usage of variables outside of their binding
+    // context and emulate traditional block scope from other languages. This is
+    // to help newcomers to the language avoid difficult bugs with variable
+    // hoisting.
     // http://eslint.org/docs/rules/block-scoped-var
     'block-scoped-var': 2,
   },

--- a/rules/filenames.js
+++ b/rules/filenames.js
@@ -3,9 +3,12 @@ module.exports = {
     'filenames',
   ],
 
+  // For complete listing of rules and what they do, check out the docs.
+  // See: https://github.com/selaux/eslint-plugin-filenames
   rules: {
     // Enforce the idiomatic kebab-case instead of snake_case or PascalCase.
-    // There are also sometimes casing issues on different platforms.
+    // Also prevents cross-platform casing issues.
+    // https://github.com/selaux/eslint-plugin-filenames
     'filenames/filenames': [ 2, '^[a-z0-9.-]+$' ],
   },
 };

--- a/rules/import.js
+++ b/rules/import.js
@@ -1,10 +1,11 @@
 var hasBabel = false;
 
+// Determine if we are using babel or not.
 try {
   require.resolve('babel-eslint');
   hasBabel = true;
 } catch (err) {
-  // do nothing
+  // If we can't load babel then stop caring.
 }
 
 module.exports = {
@@ -16,22 +17,52 @@ module.exports = {
     'import/resolve': {
       moduleDirectory: [
         'node_modules',
+        // There's no nice way of doing this yet. Presently all webpack
+        // configurations incorporate this to allow referencing source code
+        // from way up in the tree easily, so this is just hard-coded for now.
+        // Maybe there will eventually be a `.module_paths` file or something.
         './src',
       ],
     },
   },
-
+  // For complete listing of rules and what they do, check out the docs.
+  // See: https://github.com/benmosher/eslint-plugin-import
   rules: {
+    // Automatically detect unresolvable modules. Catching errors earlier is
+    // always better.
+    // https://github.com/benmosher/eslint-plugin-import#no-unresolved
     'import/no-unresolved': 2,
+
+    // Ensure named imports correspond to a named export in the imported file.
+    // Catching errors earlier is always better.
+    // https://github.com/benmosher/eslint-plugin-import#named
     'import/named': 2,
+
+    // This, unfortunately, does not work with webpack + PostCSS modules.
+    // https://github.com/benmosher/eslint-plugin-import#default
     'import/default': 0,
+
+    // Always prefere ES6 `import` unless explicitly disabled due to comment.
+    // https://github.com/benmosher/eslint-plugin-import#no-require
     'import/no-require': 2,
+
+    // All imports should come first, since they're hoisted to the top by
+    // babel automatically anyway. Additionally provide some consistency on
+    // the order in which things are imported.
+    // https://github.com/benmosher/eslint-plugin-import#imports-first
     'import/imports-first': [ 2, 'absolute-first' ],
+
+    // No point in importing things twice.
+    // https://github.com/benmosher/eslint-plugin-import#no-duplicates
     'import/no-duplicates': 2,
+
+    // Report any invalid exports, e.g. a re-export of the same name.
+    // https://github.com/benmosher/eslint-plugin-import#export
     'import/export': 2,
   },
 };
 
+// If using babel, then be sure to parse the code as ES6.
 if (hasBabel) {
   module.exports.settings['import/parser'] = 'babel-eslint';
 }

--- a/rules/modern.js
+++ b/rules/modern.js
@@ -1,20 +1,43 @@
 module.exports = {
+  // For complete listing of rules and what they do, check out the docs.
+  // See: https://github.com/eslint/eslint/tree/master/docs/rules
   rules: {
+    // If a variable is never modified, using the `const` declaration is better.
+    // `const` declaration tells readers, "this variable is never modified,"
+    // reducing cognitive load and improving maintainability.
     // http://eslint.org/docs/rules/prefer-const
     'prefer-const': 2,
 
+    // Modifying variables that are declared using const keyword will raise a
+    // runtime error. So catch this at check time instead of runtime because
+    // seeing errors sooner is better than later.
     // http://eslint.org/docs/rules/no-const-assign
     'no-const-assign': 2,
 
+    // If there are declarations of the same name in class members, the last
+    // declaration overwrites other declarations silently. It can cause
+    // unexpected behaviors. This is basically the ES6 version of ES5's
+    // rule: `no-dupe-keys`.
     // http://eslint.org/docs/rules/no-dupe-class-members
     'no-dupe-class-members': 2,
 
+    // In ES6 prefer `let` or `const` because they are block scoped (which is
+    // infiniteley more clear than function scoping), and also ensures the
+    // reader knows if the variable is intended to be modified or not. It also
+    // makes to highlight low-hanging fruit where large groups of `let` can be
+    // refactored into `const`.
     // http://eslint.org/docs/rules/no-var
     'no-var': 2,
 
+    // Use template literals instead of string concatenation. Eventually smart
+    // compiler optimizations will make these kinds of operations faster than
+    // just dumb concatenation.
     // http://eslint.org/docs/rules/prefer-template
     'prefer-template': 2,
 
+    // Enforce a quoting style that is consistent with quotes in JavaScript.
+    // JSX is not HTML. JSX is JavaScript. We use single quotes in JavaScript
+    // because they're easier to type.
     // http://eslint.org/docs/rules/jsx-quotes
     'jsx-quotes': [ 2, 'prefer-single' ],
   },

--- a/rules/react.js
+++ b/rules/react.js
@@ -2,24 +2,86 @@ module.exports = {
   plugins: [
     'react',
   ],
+  // For complete listing of rules and what they do, check out the docs.
+  // See: https://github.com/yannickcr/eslint-plugin-react/docs/rules
   rules: {
+    // For ES6 class components and stateless components this isn't necessary.
     'react/display-name': 0,
+
+    // Enforce boolean value consistency. Prefer the format that aligns with the
+    // HTML5 spec and requires less typing.
     'react/jsx-boolean-value': 2,
+
+    // This rules can help you locate potential ReferenceErrors resulting from
+    // misspellings or missing components. Akin to `no-undef`.
     'react/jsx-no-undef': 2,
+
+    // Ensure consistent component naming that aligns with community standards.
+    // Component's should be `NamedLikeThis`, `notLikeThis` and `NOTLIKETHIS`.
+    'react/jsx-pascal-case': 2,
+
+    // Don't be super-pedantic about requiring sorted properties. There may be
+    // logical orderings that are not alphabetical.
     'react/jsx-sort-props': 0,
+
+    // Don't be super-pedantic about requiring sorted propTypes. There may be
+    // logical orderings that are not alphabetical.
     'react/jsx-sort-prop-types': 0,
+
+    // The normal JSX pragma is `React.createElement`. When preferring explicit
+    // imports à la `import { ... } from 'react';` it makes more sense to alias
+    // the pragma to `createElement`. This results, roughly, in:
+    // `import { Component, createElement, ... } from 'react';`
     'react/jsx-uses-react': [ 2, {
       pragma: 'createElement',
     } ],
+
+    // This is necessary for `no-unused-vars` to work. It ensures that when JSX
+    // consumes variables they are marked as "used".
     'react/jsx-uses-vars': 2,
+
+    // Updating the state after a component mount will trigger a second render()
+    // call and can lead to property/layout thrashing.
     'react/no-did-mount-set-state': [ 2, 'allow-in-func' ],
+
+    // Updating the state after a component update will trigger a second
+    // render() call and can lead to property/layout thrashing.
     'react/no-did-update-set-state': 2,
+
+    // Prevent one file from having more than one component. In general, one
+    // component per file allows for strong isolation, easier testing and
+    // easier stubbing/mocking. For the cases in which truly private sub-
+    // components are needed, they can be provided as class methods on class
+    // components or as closures in stateless components. This is intentionally
+    // a little obtuse to encourage the minimum component "unit" being able to
+    // stand on and be tested on its own.
     'react/no-multi-comp': 2,
+
+    // In JSX all DOM properties and attributes should be camelCased to be
+    // consistent with standard JavaScript style. This can be a possible source
+    // of errors if you are used to write plain HTML.
     'react/no-unknown-property': 2,
-    'react/prop-types': 2,
+
+    // This is turned off in favor of using `flowtype` to annotate stateless
+    // function components. If your project is heavy on non-stateless components
+    // then you shoud turn this on.
+    'react/prop-types': 0,
+
+    // Ensure that whatever is creating JSX elements (i.e. `createElement`)
+    // is actually imported into the file.
+    // TODO: Enable this after the appropriate pragma patch.
     'react/react-in-jsx-scope': 0,
+
+    // Components without children can be self-closed to avoid unnecessary extra
+    // closing tag. Ensures consistency and saves space.
     'react/self-closing-comp': 2,
+
+    // Enforce multi-line JSX to be enclosed with (). This provides more legible
+    // JSX syntax where tag aligment happens on indentation boundaries for the
+    // opening and closing tag.
     'react/wrap-multilines': 2,
+
+    // Provide consistent ordering for class-style React component properties.
     'react/sort-comp': [ 2, {
       order: [
         'displayName',

--- a/rules/style.js
+++ b/rules/style.js
@@ -1,122 +1,178 @@
 module.exports = {
+  // For complete listing of rules and what they do, check out the docs.
+  // See: https://github.com/eslint/eslint/tree/master/docs/rules
   rules: {
-
-    // See: http://programmers.stackexchange.com/questions/57
+    // Although tabs make more sense semantically, spaces are just more
+    // pragmatic for now. They're always consistent across all platforms and
+    // editors.
+    // http://eslint.org/docs/rules/indent
+    // http://programmers.stackexchange.com/questions/57
     'indent': [ 2, 2 ],
 
-    // The one true brace style.
+    // The one true brace style. (That's actually what it's called).
+    // http://eslint.org/docs/rules/brace-style
     'brace-style': [ 2, '1tbs', {
       allowSingleLine: true,
     } ],
 
     // Single quotes are faster to type and seem to be a fairly general
     // convention in the JS community.
+    // http://eslint.org/docs/rules/quotes
     'quotes': [ 2, 'single', 'avoid-escape' ],
 
     // Enforce case guidelines used in Javascript. No variables_like_this or
     // VariablesLikeThis. Thoughts about properties: use an eslint ignore
     // block to marshal bad properties from APIs like foo_bar into foorBar.
     // AirBnB is less strict in this regard.
+    // http://eslint.org/docs/rules/camelcase
     'camelcase': 2,
 
+    // Spacing around commas improve readability of a list of items.
+    // http://eslint.org/docs/rules/comma-spacing
     'comma-spacing': [ 2, {
       before: false,
       after: true,
     } ],
 
+    // Using `first` just plain looks weird.
+    // http://eslint.org/docs/rules/comma-style
     'comma-style': [ 2, 'last' ],
 
     // Just convention for a lot of tools; git in particular.
-    // See: http://stackoverflow.com/questions/729692
+    // http://eslint.org/docs/rules/eol-last
+    // http://stackoverflow.com/questions/729692
     'eol-last': 2,
 
+    // Having function names can help debuggability, but with good stack traces
+    // and source maps this isn't really an issue.
+    // http://eslint.org/docs/rules/func-names
     'func-names': 0,
 
     // Things look nice "{ like: this }" and not "{like:this}".
+    // http://eslint.org/docs/rules/key-spacing
     'key-spacing': [ 2, {
       beforeColon: false,
       afterColon: true,
     } ],
 
+    // To be consistent with `key-spacing`.
+    // http://eslint.org/docs/rules/array-bracket-spacing
     'array-bracket-spacing': [ 2, 'always' ],
 
-    // 80 column max in order to fit multiple panes on a screen.
-    // TODO: Figure out how to incorporate tab sizing dynamically.
+    // 80 column max in order to fit multiple panes on a screen. This is also
+    // the traditional column count and should work well with a large variety
+    // of editors.
+    // http://eslint.org/docs/rules/max-len
     'max-len': [ 2, 80, 2 ],
 
+    // Since constructor functions are just regular functions, the only defining
+    // characteristic is that new is being used as part of the call. Native
+    // JavaScript functions begin with an uppercase letter to distinguish those
+    // functions that are to be used as constructors from functions that are
+    // not. We recommend following this pattern to more easily determine which
+    // functions are to be used as constructors.
+    // http://eslint.org/docs/rules/new-cap
     'new-cap': [ 2, {
       newIsCap: true,
       capIsNew: false,
     } ],
 
     // Prevent pointlessly nested if statements because they're harder to read.
+    // http://eslint.org/docs/rules/no-lonely-if
     'no-lonely-if': 2,
 
     // Who would do this? Honestly.
+    // http://eslint.org/docs/rules/no-mixed-spaces-and-tabs
     'no-mixed-spaces-and-tabs': [ 2, true ],
 
     // Keep things clean by avoiding unnecessary spacing.
-    'no-multiple-empty-lines': 2,
+    // http://eslint.org/docs/rules/no-multiple-empty-lines
+    'no-multiple-empty-lines': [ 2, { max: 1 } ],
 
     // Nested ternaries are just plain confusing. Avoiding them keeps the
     // code readable.
+    // http://eslint.org/docs/rules/no-nested-ternary
     'no-nested-ternary': 2,
 
-    // ?
+    // Prefer concise object literal syntax `{ }`.
+    // http://eslint.org/docs/rules/no-new-object
     'no-new-object': 2,
 
-    // Don't allow people to do stupid looking things like: foo (a, b). They
-    // should look like foo(a, b).
+    // Don't allow people to do silly looking things like: `foo (a, b)`. They
+    // should look like `foo(a, b)`.
+    // http://eslint.org/docs/rules/no-spaced-func
     'no-spaced-func': 2,
 
-    // ?
+    // Sometimes in the course of editing files, you can end up with extra
+    // whitespace at the end of lines. These whitespace differences can be
+    // picked up by source control systems and flagged as diffs, causing
+    // frustration for developers.
+    // http://eslint.org/docs/rules/no-trailing-spaces
     'no-trailing-spaces': 2,
 
-    // ?
-    // See: https://github.com/yannickcr/eslint-plugin-react/issues/86
+    // http://eslint.org/docs/rules/no-extra-parens
+    // https://github.com/yannickcr/eslint-plugin-react/issues/86
     'no-extra-parens': 0,
 
     // There are no such thing as "private" properties. Use closure
     // variables if you really need isolation.
+    // TODO: Revisit this rule.
+    // http://eslint.org/docs/rules/no-underscore-dangle
     'no-underscore-dangle': 0,
 
-    // ??
+    // A little more verbose, but is cleaner and more clear.
+    // http://eslint.org/docs/rules/one-var
     'one-var': [ 2, 'never' ],
 
-    // ?
+    // Concise, consistent.
+    // http://eslint.org/docs/rules/padded-blocks
     'padded-blocks': [ 2, 'never' ],
 
-    // ?
+    // Treat ASI as if it didn't exist and always include semicolons manually.
+    // The rationale is that it's easier to always include semicolons than to
+    // try to remember when they are or are not required, and thus decreases the
+    // possibility of introducing an error. This isn't always the case, but good
+    // enough for the majority of cases.
+    // http://eslint.org/docs/rules/semi
     'semi': [ 2, 'always' ],
 
-    // ?
+    // Ensure consistency and improve readability. Don't allow silly things like
+    // `for(var foo = 1;foo < 4;++i)`. Instead: `for(var foo = 1; foo < 4; ++i)`
+    // http://eslint.org/docs/rules/semi-spacing
     'semi-spacing': [ 2, {
       before: false,
       after: true,
     } ],
 
     // Enforce whitespace for visual clarity.
+    // http://eslint.org/docs/rules/space-after-keywords
     'space-after-keywords': [ 2, 'always' ],
 
-    // ?
+    // Enforce whitespace for visual clarity.
+    // http://eslint.org/docs/rules/space-before-blocks
     'space-before-blocks': 2,
 
-    // ?
+    // Enforce whitespace for visual clarity.
+    // http://eslint.org/docs/rules/space-before-function-paren
     'space-before-function-paren': [ 2, {
       anonymous: 'never',
       named: 'never',
     } ],
 
-    // ?
+    // Enforce whitespace for visual clarity.
+    // http://eslint.org/docs/rules/space-infix-ops
     'space-infix-ops': 2,
 
-    // ?
+    // Enforce whitespace for visual clarity.
+    // http://eslint.org/docs/rules/space-return-throw-case
     'space-return-throw-case': 2,
 
-    // Enforce whitespace because it looks nice.
+    // Enforce whitespace for visual clarity.
+    // http://eslint.org/docs/rules/spaced-comment
     'spaced-comment': 2,
 
     // Searching a file for `this` will pickup `_this` but not `self`.
+    // http://eslint.org/docs/rules/consistent-this
     'consistent-this': [ 2, '_this' ],
   },
 };


### PR DESCRIPTION
Things are always better when people know _why_ you're doing them. In the process of documenting rules a few were identified as having slight modifications to them.
- `console/debugger` now error instead of warn.
- `quote-props` from `consistent-as-needed` to `as-needed`.
- `no-multiple-empty-lines` set to max 1 empty line.

/cc @jamesdphillips @jjt @nealgranger 
