### PR TITLE
Separate environment presets from syntax presets

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": [
+    "./legacy.js",
     "./node.js"
   ],
   "rules": {

--- a/README.md
+++ b/README.md
@@ -65,11 +65,16 @@ npm run lint
 
 It's recommended you use some combination of the rule packages:
 
+*Language Presets*
  * `legacy` - Old ES5/non-babel code.
- * `browser` - If you're targeting the DOM environment.
- * `node` - If you're targeting the `node` platform.
- * `react` - If you're using the `react` framework.
  * `base` - If you're using ES6/modern code.
+
+*Environment Presets*
+ * `browser` - If you're targeting the DOM environment.
+ * `node` - If you're targeting the `node` environment.
+
+*Framework Presets*
+ * `react` - If you're using code with the `react` framework.
 
 If you need more fine-grained control you can import things in the [rules/](rules) directory.
 

--- a/node.js
+++ b/node.js
@@ -1,6 +1,5 @@
 module.exports = {
   extends: [
-    './base.js',
     './rules/node.js',
   ].map(require.resolve),
 };

--- a/react.js
+++ b/react.js
@@ -1,5 +1,12 @@
 module.exports = {
+  settings: {
+    react: {
+      pragma: 'createElement',
+    },
+  },
   extends: [
+    './base.js',
+    './rules/jsx.js',
     './rules/react.js',
   ].map(require.resolve),
 };

--- a/react.js
+++ b/react.js
@@ -1,6 +1,5 @@
 module.exports = {
   extends: [
-    './base.js',
     './rules/react.js',
   ].map(require.resolve),
 };

--- a/rules/jsx.js
+++ b/rules/jsx.js
@@ -1,0 +1,46 @@
+module.exports = {
+  plugins: [
+    'react',
+  ],
+  // For complete listing of rules and what they do, check out the docs.
+  // See: https://github.com/yannickcr/eslint-plugin-react/docs/rules
+  rules: {
+    // Enforce boolean value consistency. Prefer the format that aligns with the
+    // HTML5 spec and requires less typing.
+    'react/jsx-boolean-value': 2,
+
+    // Make it so that people don't have their closing tags all over the place.
+    'react/jsx-closing-bracket-location': [2, 'tag-aligned'],
+
+    // Keep consistent with the normal indentation style.
+    'react/jsx-indent-props': [2, 2],
+
+    // This rules can help you locate potential ReferenceErrors resulting from
+    // misspellings or missing components. Akin to `no-undef`.
+    'react/jsx-no-undef': 2,
+
+    // Ensure consistent component naming that aligns with community standards.
+    // Component's should be `NamedLikeThis`, `notLikeThis` and `NOTLIKETHIS`.
+    'react/jsx-pascal-case': 2,
+
+    // Don't be super-pedantic about requiring sorted properties. There may be
+    // logical orderings that are not alphabetical.
+    'react/jsx-sort-props': 0,
+
+    // This is necessary for `no-unused-vars` to work. It ensures that when JSX
+    // consumes variables they are marked as "used".
+    'react/jsx-uses-vars': 2,
+
+    // Components without children can be self-closed to avoid unnecessary extra
+    // closing tag. Ensures consistency and saves space.
+    'react/self-closing-comp': 2,
+
+    // Enforce multi-line JSX to be enclosed with (). This provides more legible
+    // JSX syntax where tag aligment happens on indentation boundaries for the
+    // opening and closing tag.
+    'react/wrap-multilines': 2,
+
+    // Don't let people do silly things.
+    'react/jsx-equals-spacing': [2, 'never'],
+  },
+};

--- a/rules/react.js
+++ b/rules/react.js
@@ -8,31 +8,9 @@ module.exports = {
     // For ES6 class components and stateless components this isn't necessary.
     'react/display-name': 0,
 
-    // Enforce boolean value consistency. Prefer the format that aligns with the
-    // HTML5 spec and requires less typing.
-    'react/jsx-boolean-value': 2,
-
-    // Make it so that people don't have their closing tags all over the place.
-    'react/jsx-closing-bracket-location': [2, 'tag-aligned'],
-
-    // Keep consistent with the normal indentation style.
-    'react/jsx-indent-props': [2, 2],
-
     // Warn if an element that likely requires a key prop – namely, one present
     // in an array literal or an arrow function expression.
     'react/jsx-key': 2,
-
-    // This rules can help you locate potential ReferenceErrors resulting from
-    // misspellings or missing components. Akin to `no-undef`.
-    'react/jsx-no-undef': 2,
-
-    // Ensure consistent component naming that aligns with community standards.
-    // Component's should be `NamedLikeThis`, `notLikeThis` and `NOTLIKETHIS`.
-    'react/jsx-pascal-case': 2,
-
-    // Don't be super-pedantic about requiring sorted properties. There may be
-    // logical orderings that are not alphabetical.
-    'react/jsx-sort-props': 0,
 
     // Don't be super-pedantic about requiring sorted propTypes. There may be
     // logical orderings that are not alphabetical.
@@ -42,13 +20,7 @@ module.exports = {
     // imports à la `import { ... } from 'react';` it makes more sense to alias
     // the pragma to `createElement`. This results, roughly, in:
     // `import { Component, createElement, ... } from 'react';`
-    'react/jsx-uses-react': [2, {
-      pragma: 'createElement',
-    }],
-
-    // This is necessary for `no-unused-vars` to work. It ensures that when JSX
-    // consumes variables they are marked as "used".
-    'react/jsx-uses-vars': 2,
+    'react/jsx-uses-react': 2,
 
     // Updating the state after a component mount will trigger a second render()
     // call and can lead to property/layout thrashing.
@@ -79,17 +51,7 @@ module.exports = {
 
     // Ensure that whatever is creating JSX elements (i.e. `createElement`)
     // is actually imported into the file.
-    // TODO: Enable this after the appropriate pragma patch.
-    'react/react-in-jsx-scope': 0,
-
-    // Components without children can be self-closed to avoid unnecessary extra
-    // closing tag. Ensures consistency and saves space.
-    'react/self-closing-comp': 2,
-
-    // Enforce multi-line JSX to be enclosed with (). This provides more legible
-    // JSX syntax where tag aligment happens on indentation boundaries for the
-    // opening and closing tag.
-    'react/wrap-multilines': 2,
+    'react/react-in-jsx-scope': 2,
 
     // Provide consistent ordering for class-style React component properties.
     'react/sort-comp': [2, {


### PR DESCRIPTION
For any project setup you will need to extend an environment preset and a syntax preset, i.e. `"extends": ["metalab/legacy", "metalab/node"]`
