### PR TITLE
Support for `eslint@2`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "eslint-plugin-react": "^3.11.2"
   },
   "peerDependencies": {
-    "eslint": "^1.10.3"
+    "eslint": "^1.10.3 || ^2.0.0-alpha-2"
   },
   "devDependencies": {
-    "eslint": "^1.10.3"
+    "eslint": "^2.0.0-alpha-2"
   }
 }


### PR DESCRIPTION
Not yet released, but good to start ensuring we can work with it.

TODO:
- [x] Apparently `eslint-2.0.0-alpha-2` does not satisfy `eslint>=1.0.0`?!

```
> semver.satisfies('2.0.0-alpha.2', '>=1.0.0')
false
> semver.satisfies('2.0.0', '>=1.0.0')
true
```

UPDATE: Apparently this is intentional, since `-prerelease` tends to be unstable. Closing this until `eslint@2` lands as stable.

/cc @jjt @nealgranger 
