### PR TITLE
Use `require.resolve` for imports within configs.

### DIFF
--- a/base.js
+++ b/base.js
@@ -3,5 +3,5 @@ module.exports = {
     './legacy.js',
     './rules/babel.js',
     './rules/modern.js',
-  ],
+  ].map(require.resolve),
 };

--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,5 @@
 module.exports = {
   extends: [
     './rules/browser.js',
-  ],
+  ].map(require.resolve),
 };

--- a/legacy.js
+++ b/legacy.js
@@ -6,5 +6,5 @@ module.exports = {
     './rules/filenames.js',
     './rules/import.js',
     './rules/style.js',
-  ],
+  ].map(require.resolve),
 };

--- a/node.js
+++ b/node.js
@@ -2,5 +2,5 @@ module.exports = {
   extends: [
     './base.js',
     './rules/node.js',
-  ],
+  ].map(require.resolve),
 };

--- a/react.js
+++ b/react.js
@@ -2,5 +2,5 @@ module.exports = {
   extends: [
     './base.js',
     './rules/react.js',
-  ],
+  ].map(require.resolve),
 };

--- a/rules/import.js
+++ b/rules/import.js
@@ -63,5 +63,5 @@ module.exports = {
 
 // If using babel, then be sure to parse the code as ES6.
 if (hasBabel) {
-  module.exports.settings['import/parser'] = 'babel-eslint';
+  module.exports.settings['import/parser'] = require.resolve('babel-eslint');
 }


### PR DESCRIPTION
Force imports to resolve relative to the `eslint-config-metalab` installation directory.
