### PR TITLE
New rules.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,30 @@
 sudo: false
 language: node_js
-node_js:
-  - '0.12'
-  - '4'
-  - '5'
+matrix:
+  include:
+    # Run tests in Node.js 0.12
+    - node_js: '0.12'
+
+    # Run tests in Node.js 4.x
+    - node_js: '4'
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.8
+            - g++-4.8
+
+    # Run tests in Node.js 5.x
+    - node_js: '5'
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.8
+            - g++-4.8
+
+before_install:
+  # Use GCC 4.8 if it's available
+  - 'if [ ! `which gcc-4.8` == "" ]; then export CXX=g++-4.8 && export CC=gcc-4.8; fi'

--- a/package.json
+++ b/package.json
@@ -14,18 +14,18 @@
     "test": "npm run lint"
   },
   "dependencies": {
-    "babel-eslint": "^5.0.0-beta4"
+    "babel-eslint": "^5.0.0-beta6"
   },
   "peerDependencies": {
     "eslint": "^1.10.3",
     "eslint-plugin-filenames": "^0.2.0",
-    "eslint-plugin-import": "^0.11.0",
-    "eslint-plugin-react": "^3.11.2"
+    "eslint-plugin-import": "^0.12.1",
+    "eslint-plugin-react": "^3.16.0"
   },
   "devDependencies": {
     "eslint": "^1.10.3",
     "eslint-plugin-filenames": "^0.2.0",
-    "eslint-plugin-import": "^0.11.0",
-    "eslint-plugin-react": "^3.11.2"
+    "eslint-plugin-import": "^0.12.1",
+    "eslint-plugin-react": "^3.16.0"
   }
 }

--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -1,3 +1,5 @@
+/* eslint no-magic-numbers: 0 */
+
 module.exports = {
   // For complete listing of rules and what they do, check out the docs.
   // See: https://github.com/eslint/eslint/tree/master/docs/rules
@@ -94,6 +96,12 @@ module.exports = {
     // http://eslint.org/docs/rules/no-floating-decimal
     'no-floating-decimal': 2,
 
+    // Attempt to guard against people using `this` when they shouldn't be. For
+    // cases which can result in undefined runtime behavior the author can mark
+    // the consumption of `this` in documentation and that will pass the rule.
+    // http://eslint.org/docs/rules/no-invalid-this
+    'no-invalid-this': 2,
+
     // There are some other ways to pass a string and have it interpreted as
     // code. Disable them for the same reasons as `eval`.
     // http://eslint.org/docs/rules/no-implied-eval
@@ -110,6 +118,11 @@ module.exports = {
     //  iterator function like `forEach`.
     // http://eslint.org/docs/rules/no-loop-func
     'no-loop-func': 2,
+
+    // 'Magic numbers' are numbers that occur multiple time in code without an
+    // explicit meaning. They should preferably be replaced by named constants.
+    // http://eslint.org/docs/rules/no-magic-numbers
+    'no-magic-numbers': 2,
 
     // It's possible to create multiline strings in JavaScript by using a slash
     // before a newline. Use template strings instead.

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -20,6 +20,11 @@ module.exports = {
     // http://eslint.org/docs/rules/comma-dangle
     'comma-dangle': [ 2, 'always-multiline' ],
 
+    // Arrow functions (=>) are similar in syntax to some comparison operators
+    // (>, <, <=, and >=). This rule warns against using the arrow function
+    // syntax in places where a condition is expected.
+    'no-arrow-condition': 2,
+
     // In conditional statements, it is very easy to mistype a comparison
     // operator (such as ==) as an assignment operator (such as =). This
     // prevents those common mistakes and ensures assignment is actually
@@ -146,6 +151,13 @@ module.exports = {
     // space in the code and can lead to confusion by readers.
     // http://eslint.org/docs/rules/no-unused-vars
     'no-unused-vars': 2,
+
+    // In JavaScript, prior to ES6, variable and function declarations are
+    // hoisted to the top of a scope, so it's possible to use identifiers before
+    // their formal declarations in code. This can be confusing and some believe
+    // it is best to always declare variables and functions before using them.
+    // http://eslint.org/docs/rules/no-use-before-define
+    'no-use-before-define': 2,
 
     // As par for the JavaScript course, NaN is one of the most confusing,
     // inconsistent literals in existence. It's part of the IEEE floating

--- a/rules/react.js
+++ b/rules/react.js
@@ -12,6 +12,16 @@ module.exports = {
     // HTML5 spec and requires less typing.
     'react/jsx-boolean-value': 2,
 
+    // Make it so that people don't have their closing tags all over the place.
+    'react/jsx-closing-bracket-location': [ 2, 'tag-aligned' ],
+
+    // Keep consistent with the normal indentation style.
+    'react/jsx-indent-props': [ 2, 2 ],
+
+    // Warn if an element that likely requires a key prop – namely, one present
+    // in an array literal or an arrow function expression.
+    'react/jsx-key': 2,
+
     // This rules can help you locate potential ReferenceErrors resulting from
     // misspellings or missing components. Akin to `no-undef`.
     'react/jsx-no-undef': 2,

--- a/rules/style.js
+++ b/rules/style.js
@@ -1,3 +1,5 @@
+/* eslint no-magic-numbers: 0 */
+
 module.exports = {
   // For complete listing of rules and what they do, check out the docs.
   // See: https://github.com/eslint/eslint/tree/master/docs/rules
@@ -8,6 +10,12 @@ module.exports = {
     // http://eslint.org/docs/rules/indent
     // http://programmers.stackexchange.com/questions/57
     'indent': [ 2, 2 ],
+
+    // Arrow functions can omit parentheses when they have exactly one
+    // parameter. In all other cases the parameter(s) must be wrapped in
+    // parentheses. This enforces the consistency.
+    // http://eslint.org/docs/rules/arrow-parens
+    'arrow-parens': [ 2, 'always' ],
 
     // The one true brace style. (That's actually what it's called).
     // http://eslint.org/docs/rules/brace-style
@@ -47,6 +55,11 @@ module.exports = {
     // and source maps this isn't really an issue.
     // http://eslint.org/docs/rules/func-names
     'func-names': 0,
+
+    // Mostly here to ensure consistency and avoid scope-hoisting. Either way
+    // is viable however.
+    // http://eslint.org/docs/rules/func-style
+    'func-style': [ 2, 'expression' ],
 
     // Things look nice "{ like: this }" and not "{like:this}".
     // http://eslint.org/docs/rules/key-spacing


### PR DESCRIPTION
This is obviously a breaking change. :bike: :house: 

As an interesting note this results in the (very rough) differential:

``` javascript
{
    "array-bracket-spacing": 0,
    "quotes": 0,
    "jsx-quotes": 0,
    "max-len": 0,
    "valid-jsdoc": 0,
    "comma-dangle": [2, "always-multiline"],
    "react/jsx-handler-names": 0,
    "no-shadow": 0,
}
```

against `eslint-config-defaults/configurations/walmart/es6-react`.

/cc @nealgranger @jjt 
