### PR TITLE
Tighter spacing.

### DIFF
--- a/rules/best-practices.js
+++ b/rules/best-practices.js
@@ -19,12 +19,12 @@ module.exports = {
     // around blocks, even when they are optional, because it can lead to bugs
     // and reduces code clarity.
     // http://eslint.org/docs/rules/curly
-    'curly': [ 2, 'multi-line' ],
+    'curly': [2, 'multi-line'],
 
     // Enforce a reasonable cap on functions spiralling out of control
     // with many branches.
     // http://eslint.org/docs/rules/complexity
-    'complexity': [ 2, 10 ],
+    'complexity': [2, 10],
 
     // If you have a switch block you should always cover all possible cases.
     // Since Javascript has a bad "type system" we have to have a default case
@@ -35,9 +35,9 @@ module.exports = {
     // Dot notation is often preferred because it is easier to read, less
     // verbose, and works better with aggressive JavaScript minimizers.
     // http://eslint.org/docs/rules/dot-notation
-    'dot-notation': [ 2, {
+    'dot-notation': [2, {
       allowKeywords: true,
-    } ],
+    }],
 
     // JavaScript "types" to the rescue again! `==` offers incredibly
     // inconsistent checking resulting in hard-to-find errors.
@@ -232,7 +232,7 @@ module.exports = {
 
     // Avoid pitfalls when trying to call a just-declared function.
     // http://eslint.org/docs/rules/wrap-iife
-    'wrap-iife': [ 2, 'any' ],
+    'wrap-iife': [2, 'any'],
 
     // Provide a consistent way of doing comparisons. This way is arguably a
     // more natural way to describe the comparison.

--- a/rules/docs.js
+++ b/rules/docs.js
@@ -5,10 +5,10 @@ module.exports = {
     // Enforce good documentation. Reduce the mental burden for when other
     // people try to understand or consume your code.
     // http://eslint.org/docs/rules/valid-jsdoc
-    'valid-jsdoc': [ 2, {
+    'valid-jsdoc': [2, {
       prefer: {
         return: 'returns',
       },
-    } ],
+    }],
   },
 };

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -18,7 +18,7 @@ module.exports = {
     // sometimes making it hard to tell which lines were intended to be changed
     // and making `git blame` mark one line with a possibly unrelated commit.
     // http://eslint.org/docs/rules/comma-dangle
-    'comma-dangle': [ 2, 'always-multiline' ],
+    'comma-dangle': [2, 'always-multiline'],
 
     // Arrow functions (=>) are similar in syntax to some comparison operators
     // (>, <, <=, and >=). This rule warns against using the arrow function
@@ -30,7 +30,7 @@ module.exports = {
     // prevents those common mistakes and ensures assignment is actually
     // intentional.
     // http://eslint.org/docs/rules/no-cond-assign
-    'no-cond-assign': [ 2, 'except-parens' ],
+    'no-cond-assign': [2, 'except-parens'],
 
     // While fine for debugging, (or in exceptional cases like as a plugin to a
     // logging mechanism), console output generally does not belong in
@@ -122,7 +122,7 @@ module.exports = {
     // quotes are extra and unecessary since the majority of properties should
     // be camel-cased. However, sometimes you need those odd-named properties.
     // http://eslint.org/docs/rules/quote-props
-    'quote-props': [ 2, 'as-needed' ],
+    'quote-props': [2, 'as-needed'],
 
     // Sparse arrays contain empty slots, most frequently due to multiple commas
     // being used in an array literal. Did the developer intend for there to be

--- a/rules/filenames.js
+++ b/rules/filenames.js
@@ -9,6 +9,6 @@ module.exports = {
     // Enforce the idiomatic kebab-case instead of snake_case or PascalCase.
     // Also prevents cross-platform casing issues.
     // https://github.com/selaux/eslint-plugin-filenames
-    'filenames/filenames': [ 2, '^[a-z0-9.-]+$' ],
+    'filenames/filenames': [2, '^[a-z0-9.-]+$'],
   },
 };

--- a/rules/modern.js
+++ b/rules/modern.js
@@ -39,6 +39,6 @@ module.exports = {
     // JSX is not HTML. JSX is JavaScript. We use single quotes in JavaScript
     // because they're easier to type.
     // http://eslint.org/docs/rules/jsx-quotes
-    'jsx-quotes': [ 2, 'prefer-single' ],
+    'jsx-quotes': [2, 'prefer-single'],
   },
 };

--- a/rules/react.js
+++ b/rules/react.js
@@ -13,10 +13,10 @@ module.exports = {
     'react/jsx-boolean-value': 2,
 
     // Make it so that people don't have their closing tags all over the place.
-    'react/jsx-closing-bracket-location': [ 2, 'tag-aligned' ],
+    'react/jsx-closing-bracket-location': [2, 'tag-aligned'],
 
     // Keep consistent with the normal indentation style.
-    'react/jsx-indent-props': [ 2, 2 ],
+    'react/jsx-indent-props': [2, 2],
 
     // Warn if an element that likely requires a key prop – namely, one present
     // in an array literal or an arrow function expression.
@@ -42,9 +42,9 @@ module.exports = {
     // imports à la `import { ... } from 'react';` it makes more sense to alias
     // the pragma to `createElement`. This results, roughly, in:
     // `import { Component, createElement, ... } from 'react';`
-    'react/jsx-uses-react': [ 2, {
+    'react/jsx-uses-react': [2, {
       pragma: 'createElement',
-    } ],
+    }],
 
     // This is necessary for `no-unused-vars` to work. It ensures that when JSX
     // consumes variables they are marked as "used".
@@ -52,7 +52,7 @@ module.exports = {
 
     // Updating the state after a component mount will trigger a second render()
     // call and can lead to property/layout thrashing.
-    'react/no-did-mount-set-state': [ 2, 'allow-in-func' ],
+    'react/no-did-mount-set-state': [2, 'allow-in-func'],
 
     // Updating the state after a component update will trigger a second
     // render() call and can lead to property/layout thrashing.
@@ -92,7 +92,7 @@ module.exports = {
     'react/wrap-multilines': 2,
 
     // Provide consistent ordering for class-style React component properties.
-    'react/sort-comp': [ 2, {
+    'react/sort-comp': [2, {
       order: [
         'displayName',
         'propTypes',
@@ -121,6 +121,6 @@ module.exports = {
         '/^render.+$/',
         'render',
       ],
-    } ],
+    }],
   },
 };

--- a/rules/style.js
+++ b/rules/style.js
@@ -9,24 +9,24 @@ module.exports = {
     // editors.
     // http://eslint.org/docs/rules/indent
     // http://programmers.stackexchange.com/questions/57
-    'indent': [ 2, 2 ],
+    'indent': [2, 2],
 
     // Arrow functions can omit parentheses when they have exactly one
     // parameter. In all other cases the parameter(s) must be wrapped in
     // parentheses. This enforces the consistency.
     // http://eslint.org/docs/rules/arrow-parens
-    'arrow-parens': [ 2, 'always' ],
+    'arrow-parens': [2, 'always'],
 
     // The one true brace style. (That's actually what it's called).
     // http://eslint.org/docs/rules/brace-style
-    'brace-style': [ 2, '1tbs', {
+    'brace-style': [2, '1tbs', {
       allowSingleLine: true,
-    } ],
+    }],
 
     // Single quotes are faster to type and seem to be a fairly general
     // convention in the JS community.
     // http://eslint.org/docs/rules/quotes
-    'quotes': [ 2, 'single', 'avoid-escape' ],
+    'quotes': [2, 'single', 'avoid-escape'],
 
     // Enforce case guidelines used in Javascript. No variables_like_this or
     // VariablesLikeThis. Thoughts about properties: use an eslint ignore
@@ -37,14 +37,14 @@ module.exports = {
 
     // Spacing around commas improve readability of a list of items.
     // http://eslint.org/docs/rules/comma-spacing
-    'comma-spacing': [ 2, {
+    'comma-spacing': [2, {
       before: false,
       after: true,
-    } ],
+    }],
 
     // Using `first` just plain looks weird.
     // http://eslint.org/docs/rules/comma-style
-    'comma-style': [ 2, 'last' ],
+    'comma-style': [2, 'last'],
 
     // Just convention for a lot of tools; git in particular.
     // http://eslint.org/docs/rules/eol-last
@@ -59,24 +59,28 @@ module.exports = {
     // Mostly here to ensure consistency and avoid scope-hoisting. Either way
     // is viable however.
     // http://eslint.org/docs/rules/func-style
-    'func-style': [ 2, 'expression' ],
+    'func-style': [2, 'expression'],
 
-    // Things look nice "{ like: this }" and not "{like:this}".
+    // Things look nice "{like: this}" and not "{like:this}".
     // http://eslint.org/docs/rules/key-spacing
-    'key-spacing': [ 2, {
+    'key-spacing': [2, {
       beforeColon: false,
       afterColon: true,
-    } ],
+    }],
 
-    // To be consistent with `key-spacing`.
+    // To be consistent with `array-bracket-spacing`.
+    // http://eslint.org/docs/rules/object-curly-spacing
+    'object-curly-spacing': [2, 'never'],
+
+    // To be consistent with `object-curly-spacing`.
     // http://eslint.org/docs/rules/array-bracket-spacing
-    'array-bracket-spacing': [ 2, 'always' ],
+    'array-bracket-spacing': [2, 'never'],
 
     // 80 column max in order to fit multiple panes on a screen. This is also
     // the traditional column count and should work well with a large variety
     // of editors.
     // http://eslint.org/docs/rules/max-len
-    'max-len': [ 2, 80, 2 ],
+    'max-len': [2, 80, 2],
 
     // Since constructor functions are just regular functions, the only defining
     // characteristic is that new is being used as part of the call. Native
@@ -85,10 +89,10 @@ module.exports = {
     // not. We recommend following this pattern to more easily determine which
     // functions are to be used as constructors.
     // http://eslint.org/docs/rules/new-cap
-    'new-cap': [ 2, {
+    'new-cap': [2, {
       newIsCap: true,
       capIsNew: false,
-    } ],
+    }],
 
     // Prevent pointlessly nested if statements because they're harder to read.
     // http://eslint.org/docs/rules/no-lonely-if
@@ -96,11 +100,11 @@ module.exports = {
 
     // Who would do this? Honestly.
     // http://eslint.org/docs/rules/no-mixed-spaces-and-tabs
-    'no-mixed-spaces-and-tabs': [ 2, true ],
+    'no-mixed-spaces-and-tabs': [2, true],
 
     // Keep things clean by avoiding unnecessary spacing.
     // http://eslint.org/docs/rules/no-multiple-empty-lines
-    'no-multiple-empty-lines': [ 2, { max: 1 } ],
+    'no-multiple-empty-lines': [2, {max: 1}],
 
     // Nested ternaries are just plain confusing. Avoiding them keeps the
     // code readable.
@@ -135,11 +139,11 @@ module.exports = {
 
     // A little more verbose, but is cleaner and more clear.
     // http://eslint.org/docs/rules/one-var
-    'one-var': [ 2, 'never' ],
+    'one-var': [2, 'never'],
 
     // Concise, consistent.
     // http://eslint.org/docs/rules/padded-blocks
-    'padded-blocks': [ 2, 'never' ],
+    'padded-blocks': [2, 'never'],
 
     // Treat ASI as if it didn't exist and always include semicolons manually.
     // The rationale is that it's easier to always include semicolons than to
@@ -147,19 +151,19 @@ module.exports = {
     // possibility of introducing an error. This isn't always the case, but good
     // enough for the majority of cases.
     // http://eslint.org/docs/rules/semi
-    'semi': [ 2, 'always' ],
+    'semi': [2, 'always'],
 
     // Ensure consistency and improve readability. Don't allow silly things like
     // `for(var foo = 1;foo < 4;++i)`. Instead: `for(var foo = 1; foo < 4; ++i)`
     // http://eslint.org/docs/rules/semi-spacing
-    'semi-spacing': [ 2, {
+    'semi-spacing': [2, {
       before: false,
       after: true,
-    } ],
+    }],
 
     // Enforce whitespace for visual clarity.
     // http://eslint.org/docs/rules/space-after-keywords
-    'space-after-keywords': [ 2, 'always' ],
+    'space-after-keywords': [2, 'always'],
 
     // Enforce whitespace for visual clarity.
     // http://eslint.org/docs/rules/space-before-blocks
@@ -167,10 +171,10 @@ module.exports = {
 
     // Enforce whitespace for visual clarity.
     // http://eslint.org/docs/rules/space-before-function-paren
-    'space-before-function-paren': [ 2, {
+    'space-before-function-paren': [2, {
       anonymous: 'never',
       named: 'never',
-    } ],
+    }],
 
     // Enforce whitespace for visual clarity.
     // http://eslint.org/docs/rules/space-infix-ops
@@ -186,6 +190,6 @@ module.exports = {
 
     // Searching a file for `this` will pickup `_this` but not `self`.
     // http://eslint.org/docs/rules/consistent-this
-    'consistent-this': [ 2, '_this' ],
+    'consistent-this': [2, '_this'],
   },
 };


### PR DESCRIPTION
For a time I enjoyed loose spacing, affording the visual breathing room is gave some elements; but for nested objects, single elements or one-liners it just winds up being a tad unwieldy. The compactness is also beneficial in the somewhat tight 80 character line limit.

I also realize this makes things more consistent with `(foo)` which is never written as `( foo )`.

/cc @jjt @nealgranger 
