### PR TITLE
Add `es6` environment to modern preset.

### DIFF
--- a/rules/modern.js
+++ b/rules/modern.js
@@ -41,4 +41,8 @@ module.exports = {
     // http://eslint.org/docs/rules/jsx-quotes
     'jsx-quotes': [2, 'prefer-single'],
   },
+  env: {
+    // Add globals for `Promise` and friends.
+    es6: true,
+  },
 };


### PR DESCRIPTION
This prevents warnings about `Promise` and such being undefined. Seems to make sense for the modern preset.

/cc @nealgranger @jjt 
