### PR TITLE
Update eslint-plugin-filenames rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
   },
   "peerDependencies": {
     "eslint": "^2.10.2",
-    "eslint-plugin-filenames": "^0.2.0",
+    "eslint-plugin-filenames": "^1.0.0",
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-lodash-fp": "^1.2.0",
     "eslint-plugin-react": "^5.1.1"
   },
   "devDependencies": {
     "eslint": "^2.10.2",
-    "eslint-plugin-filenames": "^0.2.0",
+    "eslint-plugin-filenames": "^1.0.0",
     "eslint-plugin-import": "^1.8.0",
     "eslint-plugin-lodash-fp": "^1.2.0",
     "eslint-plugin-react": "^5.1.1"

--- a/rules/filenames.js
+++ b/rules/filenames.js
@@ -9,6 +9,8 @@ module.exports = {
     // Enforce the idiomatic kebab-case instead of snake_case or PascalCase.
     // Also prevents cross-platform casing issues.
     // https://github.com/selaux/eslint-plugin-filenames
-    'filenames/filenames': [2, '^[a-z0-9.-]+$'],
+    'filenames/match-regex': [2, '^[a-z0-9.-]+$', true],
+    'filenames/match-exported': 2,
+    'filenames/no-index': 0,
   },
 };


### PR DESCRIPTION
The plugin's rule was split into three, used my best judgement for the other defaults based on previous projects and our style guides. 
