### PR TITLE
Update `eslint` and associated rules/packages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,9 @@ sudo: false
 language: node_js
 matrix:
   include:
-    # Run tests in Node.js 0.12
-    - node_js: '0.12'
-
     # Run tests in Node.js 4.x
     - node_js: '4'
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-4.8
-            - g++-4.8
-
     # Run tests in Node.js 5.x
     - node_js: '5'
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-4.8
-            - g++-4.8
-
-before_install:
-  # Use GCC 4.8 if it's available
-  - 'if [ ! `which gcc-4.8` == "" ]; then export CXX=g++-4.8 && export CC=gcc-4.8; fi'
+    # Run tests in Node.js 6.x
+    - node_js: '6'

--- a/package.json
+++ b/package.json
@@ -15,20 +15,22 @@
     "test": "npm run lint && npm run smoke"
   },
   "dependencies": {
-    "babel-eslint": "^6.0.4"
+    "babel-eslint": "^6.0.4",
+    "eslint-import-resolver-babel-module": "^2.0.1"
   },
   "peerDependencies": {
-    "eslint": "^2.10.2",
-    "eslint-plugin-filenames": "^0.2.0",
-    "eslint-plugin-import": "^1.8.0",
-    "eslint-plugin-lodash-fp": "^1.2.0",
-    "eslint-plugin-react": "^5.1.1"
+    "eslint": "^3.5.0",
+    "eslint-plugin-filenames": "^1.1.0",
+    "eslint-plugin-import": "^1.15.0",
+    "eslint-plugin-lodash-fp": "^2.0.1",
+    "eslint-plugin-react": "^6.3.0"
   },
   "devDependencies": {
-    "eslint": "^2.10.2",
-    "eslint-plugin-filenames": "^0.2.0",
-    "eslint-plugin-import": "^1.8.0",
-    "eslint-plugin-lodash-fp": "^1.2.0",
-    "eslint-plugin-react": "^5.1.1"
+    "babel-plugin-module-resolver": "^2.2.0",
+    "eslint": "^3.5.0",
+    "eslint-plugin-filenames": "^1.1.0",
+    "eslint-plugin-import": "^1.15.0",
+    "eslint-plugin-lodash-fp": "^2.0.1",
+    "eslint-plugin-react": "^6.3.0"
   }
 }

--- a/rules/filenames.js
+++ b/rules/filenames.js
@@ -9,6 +9,6 @@ module.exports = {
     // Enforce the idiomatic kebab-case instead of snake_case or PascalCase.
     // Also prevents cross-platform casing issues.
     // https://github.com/selaux/eslint-plugin-filenames
-    'filenames/filenames': [2, '^[a-z0-9.-]+$'],
+    'filenames/match-regex': [2, '^[a-z0-9.-]+$', true],
   },
 };

--- a/rules/import.js
+++ b/rules/import.js
@@ -13,18 +13,8 @@ module.exports = {
     'import',
   ],
 
-  settings: {
-    'import/resolve': {
-      moduleDirectory: [
-        'node_modules',
-        // There's no nice way of doing this yet. Presently all webpack
-        // configurations incorporate this to allow referencing source code
-        // from way up in the tree easily, so this is just hard-coded for now.
-        // Maybe there will eventually be a `.module_paths` file or something.
-        './src',
-      ],
-    },
-  },
+  settings: {},
+
   // For complete listing of rules and what they do, check out the docs.
   // See: https://github.com/benmosher/eslint-plugin-import
   rules: {
@@ -65,4 +55,5 @@ module.exports = {
 // If using babel, then be sure to parse the code as ES6.
 if (hasBabel) {
   module.exports.settings['import/parser'] = require.resolve('babel-eslint');
+  module.exports.settings['import/resolver'] = 'babel-module';
 }

--- a/rules/jsx.js
+++ b/rules/jsx.js
@@ -42,7 +42,7 @@ module.exports = {
     // Enforce multi-line JSX to be enclosed with (). This provides more legible
     // JSX syntax where tag aligment happens on indentation boundaries for the
     // opening and closing tag.
-    'react/wrap-multilines': 2,
+    'react/jsx-wrap-multilines': 2,
 
     // Don't let people do silly things.
     'react/jsx-equals-spacing': [2, 'never'],

--- a/rules/react.js
+++ b/rules/react.js
@@ -24,7 +24,7 @@ module.exports = {
 
     // Updating the state after a component mount will trigger a second render()
     // call and can lead to property/layout thrashing.
-    'react/no-did-mount-set-state': [2, 'allow-in-func'],
+    'react/no-did-mount-set-state': 2,
 
     // Updating the state after a component update will trigger a second
     // render() call and can lead to property/layout thrashing.


### PR DESCRIPTION
Bringing you `eslint^3.5.0` with better support for custom package resolution. Support for `node^0.12` is dropped and support for `node^6` is added. This is obviously a major version bump.

/cc @nealgranger @qiushihe 
