### PR TITLE
Fix `unable to load resolver` error.

### DIFF
--- a/rules/import.js
+++ b/rules/import.js
@@ -55,5 +55,6 @@ module.exports = {
 // If using babel, then be sure to parse the code as ES6.
 if (hasBabel) {
   module.exports.settings['import/parser'] = require.resolve('babel-eslint');
-  module.exports.settings['import/resolver'] = 'babel-module';
+  module.exports.settings['import/resolver'] =
+    require.resolve('eslint-import-resolver-babel-module');
 }


### PR DESCRIPTION
Sometimes it doesn't like the fact the babel resolver is nested deep in `node_modules` somewhere. This fixes that.

/cc @nealgranger 