### PR TITLE
Use new resolver.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,22 +15,25 @@
     "test": "npm run lint && npm run smoke"
   },
   "dependencies": {
-    "babel-eslint": "^6.0.4",
-    "eslint-import-resolver-babel-module": "^2.0.1"
+    "babel-eslint": "^7.1.1",
+    "eslint-import-resolver-babel-module": "^3.0.0"
   },
   "peerDependencies": {
     "eslint": "^3.5.0",
+    "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-filenames": "^1.1.0",
-    "eslint-plugin-import": "^1.15.0",
-    "eslint-plugin-lodash-fp": "^2.0.1",
-    "eslint-plugin-react": "^6.3.0"
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-lodash-fp": "^2.1.3",
+    "eslint-plugin-react": "^6.10.0"
   },
   "devDependencies": {
-    "babel-plugin-module-resolver": "^2.2.0",
+    "babel-core": "^6.18.2",
+    "babel-plugin-module-resolver": "^2.5.0",
     "eslint": "^3.5.0",
+    "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-filenames": "^1.1.0",
-    "eslint-plugin-import": "^1.15.0",
-    "eslint-plugin-lodash-fp": "^2.0.1",
-    "eslint-plugin-react": "^6.3.0"
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-lodash-fp": "^2.1.3",
+    "eslint-plugin-react": "^6.10.0"
   }
 }

--- a/rules/babel.js
+++ b/rules/babel.js
@@ -1,4 +1,7 @@
 module.exports = {
+  plugins: [
+    'babel',
+  ],
   // Use the power of babel for parsing. This allows for use of newer versions
   // of Javascript and things like JSX. It provides a more consistent experience
   // than trying to use eslint's native `espree`.

--- a/rules/lodash-fp.js
+++ b/rules/lodash-fp.js
@@ -17,7 +17,7 @@ module.exports = {
     'lodash-fp/no-chain': 2,
 
     // Avoid unnecessary function wrapping.
-    'lodash-fp/no-extraneous-function-wrapping': 2,
+    'lodash-fp/no-extraneous-function-wrapping': 0,
 
     // No extraneous parameters in iteratees.
     'lodash-fp/no-extraneous-iteratee-args': 2,

--- a/rules/style.js
+++ b/rules/style.js
@@ -65,9 +65,10 @@ module.exports = {
     'func-names': 0,
 
     // Mostly here to ensure consistency and avoid scope-hoisting. Either way
-    // is viable however.
+    // is viable however. Not enforcing this because their are advantages to
+    // using both styles.
     // http://eslint.org/docs/rules/func-style
-    'func-style': [2, 'expression'],
+    'func-style': 0,
 
     // Things look nice "{like: this}" and not "{like:this}".
     // http://eslint.org/docs/rules/key-spacing

--- a/rules/style.js
+++ b/rules/style.js
@@ -1,3 +1,13 @@
+var hasBabel = false;
+
+// Determine if we are using babel or not.
+try {
+  require.resolve('babel-eslint');
+  hasBabel = true;
+} catch (err) {
+  // If we can't load babel then stop caring.
+}
+
 module.exports = {
   // For complete listing of rules and what they do, check out the docs.
   // See: https://github.com/eslint/eslint/tree/master/docs/rules
@@ -187,3 +197,11 @@ module.exports = {
     'consistent-this': [2, '_this'],
   },
 };
+
+if (hasBabel) {
+  // Copy existing config to babel variants.
+  module.exports.rules['babel/object-curly-spacing'] =
+    module.exports.rules['object-curly-spacing'];
+  // Disable non-babel variants.
+  module.exports.rules['object-curly-spacing'] = 0;
+}


### PR DESCRIPTION
Use `babel-plugin-module-resolver` for handling resolving `require` and `import` statements. Also update all the dependencies while we're at it. This will require a major version bump because `peerDependencies` have been updated.