### PR TITLE
Fix broken `import/resolver` config.

### DIFF
--- a/rules/import.js
+++ b/rules/import.js
@@ -55,6 +55,7 @@ module.exports = {
 // If using babel, then be sure to parse the code as ES6.
 if (hasBabel) {
   module.exports.settings['import/parser'] = require.resolve('babel-eslint');
-  module.exports.settings['import/resolver'] =
-    require.resolve('eslint-import-resolver-babel-module');
+  module.exports.settings['import/resolver'] = {};
+  module.exports.settings['import/resolver']
+    [require.resolve('eslint-import-resolver-babel-module')] = {};
 }


### PR DESCRIPTION
The `import/resolver` setting must be set as a resolver/settings key/value pair to be loaded correctly.

See: https://github.com/tleunen/eslint-import-resolver-babel-module/pull/47.