### PR TITLE
Remove `metalab` from resolver.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-metalab",
-  "version": "6.0.1",
+  "version": "7.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "babel-eslint": "^8.0.0-alpha.17",
+    "chalk": "^2.1.0",
     "eslint-import-resolver-babel-module": "^4.0.0-beta.3",
     "eslint-import-resolver-node": "^0.3.1",
     "eslint-plugin-babel": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "babel-eslint": "^8.0.0-alpha.17",
     "eslint-import-resolver-babel-module": "^4.0.0-beta.3",
+    "eslint-import-resolver-node": "^0.3.1",
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-filenames": "^1.2.0",
     "eslint-plugin-flowtype": "^2.35.0",

--- a/rules/import.js
+++ b/rules/import.js
@@ -1,5 +1,7 @@
 var hasBabel = false;
+var hasBabelResolver = false;
 var resolve = require('resolve');
+var chalk = require('chalk');
 
 // Determine if we are using babel or not.
 try {
@@ -9,6 +11,16 @@ try {
   hasBabel = true;
 } catch (err) {
   // If we can't load babel then stop caring.
+}
+
+// Determine if we are using babel resolver or not.
+try {
+  resolve.sync('babel-plugin-module-resolver', {
+    basedir: module.parent.paths[0],
+  });
+  hasBabelResolver = true;
+} catch (err) {
+  // If we can't load babel resolver then stop caring.
 }
 
 module.exports = {
@@ -56,7 +68,18 @@ if (hasBabel) {
   module.exports.settings['import/parser'] = require.resolve(
     'babel-eslint'
   );
-  module.exports.settings['import/resolver'] = {};
-  module.exports.settings['import/resolver']
-    [require.resolve('eslint-import-resolver-babel-module')] = {};
+  if (hasBabelResolver) {
+    if (
+      typeof require('babel-plugin-module-resolver').resolvePath !== 'function'
+    ) {
+      console.log( // eslint-disable-line no-console
+        chalk.red('error'),
+        'babel-plugin-module-resolver ^3 required\n'
+      );
+      process.exit(1);
+    }
+    module.exports.settings['import/resolver'] = {};
+    module.exports.settings['import/resolver']
+      [require.resolve('eslint-import-resolver-babel-module')] = {};
+  }
 }

--- a/rules/import.js
+++ b/rules/import.js
@@ -53,10 +53,10 @@ module.exports = {
 
 // If using babel, then be sure to parse the code as ES6.
 if (hasBabel) {
-  module.exports.settings['metalab/import/parser'] = require.resolve(
+  module.exports.settings['import/parser'] = require.resolve(
     'babel-eslint'
   );
-  module.exports.settings['metalab/import/resolver'] = {};
-  module.exports.settings['metalab/import/resolver']
+  module.exports.settings['import/resolver'] = {};
+  module.exports.settings['import/resolver']
     [require.resolve('eslint-import-resolver-babel-module')] = {};
 }

--- a/test/smoke/resolve/.babelrc
+++ b/test/smoke/resolve/.babelrc
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    ["module-resolver", {"alias": {"": "./src"}, "cwd": "babelrc"}]
+  ]
+}

--- a/test/smoke/resolve/.eslintrc
+++ b/test/smoke/resolve/.eslintrc
@@ -1,0 +1,2 @@
+extends:
+  - ../../../base.js

--- a/test/smoke/resolve/src/a.js
+++ b/test/smoke/resolve/src/a.js
@@ -1,0 +1,3 @@
+import {foo} from '/b';
+
+export const bar = () => foo;

--- a/test/smoke/resolve/src/b.js
+++ b/test/smoke/resolve/src/b.js
@@ -1,0 +1,1 @@
+export const foo = 'hello';


### PR DESCRIPTION
Fixes the resolver to actually work properly since `import/resolver` is hardcoded in another module. Also adds some version checking and extra safety features.